### PR TITLE
Updated to gulp 4 to be able to build using more recent versions of node

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,9 +10,9 @@
   gulp = require('gulp');
   rename = require('gulp-rename');
   uglify = require('gulp-uglify');
-  gulp.task('build', ['wasm', 'minify']).task('wasm', function(callback){
+  gulp.task('wasm', function(callback){
     var files, functions, optimize, clang_opts, command;
-    files = ['vendor/src/protocol/cipherstate.c', 'vendor/src/protocol/dhstate.c', 'vendor/src/protocol/errors.c', 'vendor/src/protocol/handshakestate.c', 'vendor/src/protocol/hashstate.c', 'vendor/src/protocol/internal.c', 'vendor/src/protocol/names.c', 'vendor/src/protocol/patterns.c', 'vendor/src/protocol/randstate.c', 'vendor/src/protocol/signstate.c', 'vendor/src/protocol/symmetricstate.c', 'vendor/src/protocol/util.c', 'vendor/src/backend/ref/dh-curve448.c', 'vendor/src/backend/ref/dh-newhope.c', 'vendor/src/backend/ref/hash-blake2s.c', 'vendor/src/crypto/blake2/blake2s.c', 'vendor/src/crypto/curve448/curve448.c', 'vendor/src/crypto/goldilocks/src/p448/arch_32/p448.c', 'vendor/src/crypto/newhope/batcher.c', 'vendor/src/crypto/newhope/error_correction.c', 'vendor/src/crypto/newhope/fips202.c', 'vendor/src/crypto/newhope/newhope.c', 'vendor/src/crypto/newhope/ntt.c', 'vendor/src/crypto/newhope/poly.c', 'vendor/src/crypto/newhope/precomp.c', 'vendor/src/crypto/newhope/reduce.c', 'vendor/src/backend/ref/cipher-aesgcm.c', 'vendor/src/backend/ref/cipher-aesgcm.c', 'vendor/src/backend/ref/cipher-chachapoly.c', 'vendor/src/backend/ref/dh-curve25519.c', 'vendor/src/backend/ref/hash-blake2b.c', 'vendor/src/backend/ref/hash-sha256.c', 'vendor/src/backend/ref/hash-sha512.c', 'vendor/src/backend/ref/sign-ed25519.c', 'vendor/src/crypto/aes/rijndael-alg-fst.c', 'vendor/src/crypto/blake2/blake2b.c', 'vendor/src/crypto/chacha/chacha.c', 'vendor/src/crypto/donna/poly1305-donna.c', 'vendor/src/crypto/ghash/ghash.c', 'vendor/src/crypto/newhope/crypto_stream_chacha20.c', 'vendor/src/crypto/sha2/sha256.c', 'vendor/src/crypto/sha2/sha512.c', 'vendor/src/crypto/ed25519/ed25519.c'].join(' ');
+    files = ['vendor/src/protocol/cipherstate.c', 'vendor/src/protocol/dhstate.c', 'vendor/src/protocol/errors.c', 'vendor/src/protocol/handshakestate.c', 'vendor/src/protocol/hashstate.c', 'vendor/src/protocol/internal.c', 'vendor/src/protocol/names.c', 'vendor/src/protocol/patterns.c', 'vendor/src/protocol/randstate.c', 'vendor/src/protocol/signstate.c', 'vendor/src/protocol/symmetricstate.c', 'vendor/src/protocol/util.c', 'vendor/src/backend/ref/dh-curve448.c', 'vendor/src/backend/ref/dh-newhope.c', 'vendor/src/backend/ref/hash-blake2s.c', 'vendor/src/crypto/blake2/blake2s.c', 'vendor/src/crypto/curve448/curve448.c', 'vendor/src/crypto/goldilocks/src/p448/arch_32/p448.c', 'vendor/src/crypto/newhope/batcher.c', 'vendor/src/crypto/newhope/error_correction.c', 'vendor/src/crypto/newhope/fips202.c', 'vendor/src/crypto/newhope/newhope.c', 'vendor/src/crypto/newhope/ntt.c', 'vendor/src/crypto/newhope/poly.c', 'vendor/src/crypto/newhope/precomp.c', 'vendor/src/crypto/newhope/reduce.c', 'vendor/src/backend/ref/cipher-aesgcm.c', 'vendor/src/backend/ref/cipher-chachapoly.c', 'vendor/src/backend/ref/dh-curve25519.c', 'vendor/src/backend/ref/hash-blake2b.c', 'vendor/src/backend/ref/hash-sha256.c', 'vendor/src/backend/ref/hash-sha512.c', 'vendor/src/backend/ref/sign-ed25519.c', 'vendor/src/crypto/aes/rijndael-alg-fst.c', 'vendor/src/crypto/blake2/blake2b.c', 'vendor/src/crypto/chacha/chacha.c', 'vendor/src/crypto/donna/poly1305-donna.c', 'vendor/src/crypto/ghash/ghash.c', 'vendor/src/crypto/newhope/crypto_stream_chacha20.c', 'vendor/src/crypto/sha2/sha256.c', 'vendor/src/crypto/sha2/sha512.c', 'vendor/src/crypto/ed25519/ed25519.c'].join(' ');
     /**
      * There are many functions exposed by the library, but only subset of them is used in production, so the rest are still here, uncomment when/if needed
      * for debugging or other purposes
@@ -32,9 +32,11 @@
       }
       callback(error);
     });
-  }).task('minify', function(){
+  });
+  gulp.task('minify', function(){
     return gulp.src("src/index.js").pipe(uglify()).pipe(rename({
       suffix: '.min'
     })).pipe(gulp.dest('src'));
   });
+  gulp.task('build', gulp.series(['wasm', 'minify']));
 }).call(this);

--- a/gulpfile.ls
+++ b/gulpfile.ls
@@ -9,7 +9,6 @@ rename	= require('gulp-rename')
 uglify	= require('gulp-uglify')
 
 gulp
-	.task('build', ['wasm', 'minify'])
 	.task('wasm', (callback) !->
 		files		= [
 			'vendor/src/protocol/cipherstate.c'
@@ -38,7 +37,6 @@ gulp
 			'vendor/src/crypto/newhope/poly.c'
 			'vendor/src/crypto/newhope/precomp.c'
 			'vendor/src/crypto/newhope/reduce.c'
-			'vendor/src/backend/ref/cipher-aesgcm.c'
 			'vendor/src/backend/ref/cipher-aesgcm.c'
 			'vendor/src/backend/ref/cipher-chachapoly.c'
 			'vendor/src/backend/ref/dh-curve25519.c'
@@ -230,6 +228,8 @@ gulp
 			callback(error)
 		)
 	)
+
+gulp
 	.task('minify', ->
 		gulp.src("src/index.js")
 			.pipe(uglify())
@@ -238,3 +238,4 @@ gulp
 			))
 			.pipe(gulp.dest('src'))
 	)
+gulp.task('build', gulp.series(['wasm', 'minify']))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-	"name"            : "noise-c.wasm",
-	"description"     : "rweather/noise-c compiled to WebAssembly using Emscripten and optimized for small size",
-	"keywords"        : [
+	"name": "noise-c.wasm",
+	"description": "rweather/noise-c compiled to WebAssembly using Emscripten and optimized for small size",
+	"keywords": [
 		"noise",
 		"noise protocol",
 		"noise-c",
@@ -12,29 +12,29 @@
 		"wasm",
 		"emscripten"
 	],
-	"version"         : "0.4.0",
-	"homepage"        : "https://github.com/nazar-pc/noise-c.wasm",
-	"author"          : "Nazar Mokrynskyi <nazar@mokrynskyi.com>",
-	"repository"      : {
-		"type" : "git",
-		"url"  : "git://github.com/nazar-pc/noise-c.wasm.git"
+	"version": "0.4.0",
+	"homepage": "https://github.com/nazar-pc/noise-c.wasm",
+	"author": "Nazar Mokrynskyi <nazar@mokrynskyi.com>",
+	"repository": {
+		"type": "git",
+		"url": "git://github.com/nazar-pc/noise-c.wasm.git"
 	},
-	"license"         : "0BSD",
-	"main"            : "src/index.js",
-	"files"           : [
+	"license": "0BSD",
+	"main": "src/index.js",
+	"files": [
 		"src"
 	],
-	"scripts"         : {
-		"test"   : "tape tests/**/*.js",
+	"scripts": {
+		"test": "tape tests/**/*.js",
 		"test-implementation": "tape tests/*State.js",
 		"test-vector": "tape tests/vectors.js",
-		"vendor" : "git clone https://github.com/rweather/noise-c.git vendor; cd vendor; git checkout 40b64ab83d4ecfdbefcab319a91761507e9fb98c",
-		"build"  : "gulp build"
+		"vendor": "git clone https://github.com/rweather/noise-c.git vendor; cd vendor; git checkout 40b64ab83d4ecfdbefcab319a91761507e9fb98c",
+		"build": "gulp build"
 	},
-	"devDependencies" : {
-		"gulp"        : "^3.9.1",
-		"gulp-rename" : "^1.2.2",
-		"gulp-uglify" : "^3.0.0",
-		"tape"        : "^4.9.0"
+	"devDependencies": {
+		"gulp": "^4.0.2",
+		"gulp-rename": "^1.2.2",
+		"gulp-uglify": "^3.0.0",
+		"tape": "^4.9.0"
 	}
 }


### PR DESCRIPTION
Gulp 3 is deprecated and actually doesn't work with recent versions of node/npm. This merely updates Gulp a fixes a couple other issues:
• duplicate cipher-aesgcm.c entry on list of files to compile
• updated gulpfile to be compatible with gulp 4